### PR TITLE
Add multipart sign api for cadence scripts

### DIFF
--- a/flowscripts/emerald_identity.js
+++ b/flowscripts/emerald_identity.js
@@ -1,11 +1,12 @@
-const fcl = require("@onflow/fcl");
-const t = require("@onflow/types");
-const { sendTransaction } = require("../helperfunctions/sendTransaction.js");
-const { setEnvironment } = require("flow-cadut");
+const fcl = require('@onflow/fcl')
+const t = require('@onflow/types')
+const { sendTransaction } = require('../helperfunctions/sendTransaction.js')
+const { setEnvironment } = require('flow-cadut')
 
 const checkEmeraldIdentityDiscord = async (discordID) => {
-  await setEnvironment("testnet");
-  const accountResponse = await fcl.send([
+  await setEnvironment('testnet')
+  const accountResponse = await fcl
+    .send([
       fcl.script`
       import EmeraldIdentity from 0x4e190c2eb6d78faa
 
@@ -13,35 +14,64 @@ const checkEmeraldIdentityDiscord = async (discordID) => {
         return EmeraldIdentity.getAccountFromDiscord(discordID: discordID)
       }
       `,
-      fcl.args([
-          fcl.arg(discordID, t.String)
-      ])
-  ]).then(fcl.decode);
+      fcl.args([fcl.arg(discordID, t.String)]),
+    ])
+    .then(fcl.decode)
 
-  return accountResponse;
+  return accountResponse
 }
 
 const checkEmeraldIdentityAccount = async (account) => {
-    await setEnvironment("testnet");
-    const accountResponse = await fcl.send([
-        fcl.script`
+  await setEnvironment('testnet')
+  const accountResponse = await fcl
+    .send([
+      fcl.script`
         import EmeraldIdentity from 0x4e190c2eb6d78faa
   
         pub fun main(account: Address): String? {
           return EmeraldIdentity.getDiscordFromAccount(account: account)
         }
         `,
-        fcl.args([
-            fcl.arg(account, t.Address)
-        ])
-    ]).then(fcl.decode);
-  
-    return accountResponse;
+      fcl.args([fcl.arg(account, t.Address)]),
+    ])
+    .then(fcl.decode)
+
+  return accountResponse
 }
 
 const initializeEmeraldID = async (account, discordID) => {
-    const code = `
-    import EmeraldIdentity from 0x4e190c2eb6d78faa
+  const code = trxScripts['initializeEmeraldID']()
+
+  const args = [fcl.arg(account, t.Address), fcl.arg(discordID, t.String)]
+
+  const transactionId = await sendTransaction(code, args)
+
+  try {
+    await fcl.tx(transactionId).onceSealed()
+    return true
+  } catch (e) {
+    console.log(e)
+    return false
+  }
+}
+
+const deleteEmeraldID = async (account, discordID) => {
+  const args = [fcl.arg(account, t.Address), fcl.arg(discordID, t.String)]
+  const code = trxScripts['deleteEmeraldID']()
+
+  const transactionId = await sendTransaction(code, args)
+
+  try {
+    await fcl.tx(transactionId).onceSealed()
+    return true
+  } catch (e) {
+    console.log(e)
+    return false
+  }
+}
+
+const initializeEmeraldIDCode = (address = '0x4e190c2eb6d78faa') => {
+  return `import EmeraldIdentity from ${address}
 
     transaction(account: Address, discordID: String) {
         prepare(signer: AuthAccount) {
@@ -53,59 +83,35 @@ const initializeEmeraldID = async (account, discordID) => {
         execute {
 
         }
-    }
-    `;
-    const args = [
-        fcl.arg(account, t.Address),
-        fcl.arg(discordID, t.String)
-    ];
-
-    const transactionId = await sendTransaction(code, args);
-
-    try {
-        await fcl.tx(transactionId).onceSealed();
-        return true;
-    } catch(e) {
-        console.log(e);
-        return false;
-    }
+    }`
 }
 
-const deleteEmeraldID = async (account, discordID) => {
-    const args = [
-        fcl.arg(account, t.Address),
-        fcl.arg(discordID, t.String)
-    ]
-    const code = `
-    import EmeraldIdentity from 0x4e190c2eb6d78faa
-
+const deleteEmeraldIDCode = (address = '0x4e190c2eb6d78faa') => {
+  return `
+    import EmeraldIdentity from ${address}
+    
     transaction(account: Address, discordID: String) {
         prepare(signer: AuthAccount) {
             let administrator = signer.borrow<&EmeraldIdentity.Administrator>(from: EmeraldIdentity.EmeraldIDAdministrator)
                                         ?? panic("Could not borrow the administrator")
             administrator.reset(account: account, discordID: discordID)
         }
-
-        execute {
-
-        }
-    }
-    `;
     
-    const transactionId = await sendTransaction(code, args)
+        execute {
+    
+        }
+    }`
+}
 
-    try {
-        await fcl.tx(transactionId).onceSealed();
-        return true;
-    } catch(e) {
-        console.log(e);
-        return false;
-    }
+const trxScripts = {
+  initializeEmeraldID: initializeEmeraldIDCode,
+  deleteEmeraldID: deleteEmeraldIDCode,
 }
 
 module.exports = {
   checkEmeraldIdentityDiscord,
   checkEmeraldIdentityAccount,
   initializeEmeraldID,
-  deleteEmeraldID
+  deleteEmeraldID,
+  trxScripts,
 }

--- a/main.js
+++ b/main.js
@@ -1,237 +1,277 @@
-require('dotenv').config();
-const { Client, Intents, Collection, MessageActionRow, MessageButton, MessageEmbed } = require('discord.js');
-const { getBalance } = require('./flowscripts/check_token.js');
-const { getBalancev2 } = require('./flowscripts/check_tokenv2.js');
-const { checkEmeraldIdentityDiscord, deleteEmeraldID } = require('./flowscripts/emerald_identity.js');
-const { encrypt, decrypt } = require('./helperfunctions/encryption.js');
-const { authorizationFunctionProposer, authorizationFunction } = require('./helperfunctions/authorization.js');
+require('dotenv').config()
+const {
+  Client,
+  Intents,
+  Collection,
+  MessageActionRow,
+  MessageButton,
+  MessageEmbed,
+} = require('discord.js')
+const { getBalance } = require('./flowscripts/check_token.js')
+const { getBalancev2 } = require('./flowscripts/check_tokenv2.js')
+const {
+  checkEmeraldIdentityDiscord,
+  deleteEmeraldID,
+  trxScripts,
+} = require('./flowscripts/emerald_identity.js')
+const { encrypt, decrypt } = require('./helperfunctions/encryption.js')
+const {
+  authorizationFunctionProposer,
+  authorizationFunction,
+  sign,
+} = require('./helperfunctions/authorization.js')
 
-const fs = require('fs');
-const fcl = require("@onflow/fcl");
-const t = require("@onflow/types");
-const { setEnvironment } = require("flow-cadut");
+const fs = require('fs')
+const fcl = require('@onflow/fcl')
+const t = require('@onflow/types')
+const { setEnvironment } = require('flow-cadut')
 
-const express = require('express');
-const bodyParser = require('body-parser');
+const express = require('express')
+const bodyParser = require('body-parser')
 
-const app = express();
-const cors = require('cors');
-const { set } = require('express/lib/application');
+const app = express()
+const cors = require('cors')
+const { set } = require('express/lib/application')
 var corsOptions = {
-    origin: ['https://pedantic-darwin-e512ad.netlify.app', 'http://localhost:3000'],
-    credentials: true,
-    methods: ['GET', 'POST']
-};
-app.use(cors(corsOptions));
-const port = process.env.PORT || 5000;
+  origin: ['https://pedantic-darwin-e512ad.netlify.app', 'http://localhost:3000'],
+  credentials: true,
+  methods: ['GET', 'POST'],
+}
+app.use(cors(corsOptions))
+const port = process.env.PORT || 5000
 
-const prefix = '!';
-const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
+const prefix = '!'
+const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] })
 
 // Gets all of our commands from our commands folder
-client.commands = new Collection();
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+client.commands = new Collection()
+const commandFiles = fs.readdirSync('./commands').filter((file) => file.endsWith('.js'))
 for (const file of commandFiles) {
-    const command = require(`./commands/${file}`);
-    // command.name is the name of the file,
-    // and command has a list of all the module exports
-    // in that file.
-    client.commands.set(command.name, command);
+  const command = require(`./commands/${file}`)
+  // command.name is the name of the file,
+  // and command has a list of all the module exports
+  // in that file.
+  client.commands.set(command.name, command)
 }
 
 client.once('ready', () => {
-    console.log('Emerald bot is online!');
+  console.log('Emerald bot is online!')
 })
 
 // When a user types a message
-client.on('messageCreate', message => {
-    if (!message.content.startsWith(prefix) || message.author.bot) return;
+client.on('messageCreate', (message) => {
+  if (!message.content.startsWith(prefix) || message.author.bot) return
 
-    const args = message.content.slice(prefix.length).split(/ +/);
-    const command = args.shift().toLowerCase();
+  const args = message.content.slice(prefix.length).split(/ +/)
+  const command = args.shift().toLowerCase()
 
-    // Executes the youtube.js file
-    if (command === 'test') {
-        console.log("wtf")
-        message.channel.send('Testing!');
-    } else if (command === 'youtube') {
-        client.commands.get('youtube').execute(message, args);
-    } else if (command === 'role') {
-        client.commands.get('role').execute(message, args);
-    } else if (command === 'setup') {
-        client.commands.get('setup').execute(message, args);
-    } else if (command === 'emeraldidrole') {
-        client.commands.get('getEmeraldIDRole').execute(message, args);
-    }
+  // Executes the youtube.js file
+  if (command === 'test') {
+    console.log('wtf')
+    message.channel.send('Testing!')
+  } else if (command === 'youtube') {
+    client.commands.get('youtube').execute(message, args)
+  } else if (command === 'role') {
+    client.commands.get('role').execute(message, args)
+  } else if (command === 'setup') {
+    client.commands.get('setup').execute(message, args)
+  } else if (command === 'emeraldidrole') {
+    client.commands.get('getEmeraldIDRole').execute(message, args)
+  }
 })
 
-client.on('interactionCreate', async interaction => {
-    if (!interaction.isButton()) return;
+client.on('interactionCreate', async (interaction) => {
+  if (!interaction.isButton()) return
 
-    if (interaction.customId.split('-').length === 3) {
-        let interactionCustomId = interaction.customId.split('-');
-        let encrypted = encrypt(interaction.member.id + '///' + interaction.guild.id + '///' + interactionCustomId[1])
-    
-        // const botInfo = new MessageEmbed().addField(`Hello there! Please click [this](http://localhost:3000/?id=${args.uuid}) link to gain access to Emerald City.`)
-        const exampleEmbed = new MessageEmbed()
-            .setColor('#5bc595')
-            .setDescription('Click the link below to verify your account.')
-            .setTimestamp()
-    
-        const row = new MessageActionRow()
-            .addComponents(
-                new MessageButton()
-                    .setURL('https://pedantic-darwin-e512ad.netlify.app/' + interactionCustomId[0] + '/?id=' + encrypted)
-                    .setLabel('Verify Account')
-                    .setStyle('LINK')
-            );
-    
-        interaction.reply({ ephemeral: true, embeds: [exampleEmbed], components: [row] })
-    } else if (interaction.customId.split('-').length === 2) {
-        let interactionCustomId = interaction.customId.split('-');
-        let roleId = interactionCustomId[1];
+  if (interaction.customId.split('-').length === 3) {
+    let interactionCustomId = interaction.customId.split('-')
+    let encrypted = encrypt(
+      interaction.member.id + '///' + interaction.guild.id + '///' + interactionCustomId[1],
+    )
 
-        let account = await checkEmeraldIdentityDiscord(interaction.member.id);
-        console.log("Returned account from ecid", account);
+    // const botInfo = new MessageEmbed().addField(`Hello there! Please click [this](http://localhost:3000/?id=${args.uuid}) link to gain access to Emerald City.`)
+    const exampleEmbed = new MessageEmbed()
+      .setColor('#5bc595')
+      .setDescription('Click the link below to verify your account.')
+      .setTimestamp()
 
-        if (account) {
-            /* For EmeraldID in EmeraldCity ONLY */
-            if (roleId === process.env.EMERALDIDROLE) {
-                    interaction.member.roles.add(roleId).catch((e) => console.log(e));
-                    interaction.reply({content: "You have been given the " + `<@&${roleId}>` + " role.", ephemeral: true});
-                    return;
-            } else {
-                let guildInfo = await getBalancev2(account, interaction.guild.id, roleId);
-                if (!guildInfo) {
-                    interaction.reply({content: "Error", ephemeral: true});
-                    return;
-                };
-                let { result, number } = guildInfo;
-                if (result && (result >= number)) {
-                    console.log("Adding role...");
-                    interaction.member.roles.add(roleId).catch((e) => console.log(e));
-                    interaction.reply({content: "You have been given the " + `<@&${roleId}>` + " role.", ephemeral: true});
-                    return;
-                }
-                interaction.reply({content: "You do not have enough tokens.", ephemeral: true});
-                return;
-            }
+    const row = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setURL(
+          'https://pedantic-darwin-e512ad.netlify.app/' +
+            interactionCustomId[0] +
+            '/?id=' +
+            encrypted,
+        )
+        .setLabel('Verify Account')
+        .setStyle('LINK'),
+    )
+
+    interaction.reply({ ephemeral: true, embeds: [exampleEmbed], components: [row] })
+  } else if (interaction.customId.split('-').length === 2) {
+    let interactionCustomId = interaction.customId.split('-')
+    let roleId = interactionCustomId[1]
+
+    let account = await checkEmeraldIdentityDiscord(interaction.member.id)
+    console.log('Returned account from ecid', account)
+
+    if (account) {
+      /* For EmeraldID in EmeraldCity ONLY */
+      if (roleId === process.env.EMERALDIDROLE) {
+        interaction.member.roles.add(roleId).catch((e) => console.log(e))
+        interaction.reply({
+          content: 'You have been given the ' + `<@&${roleId}>` + ' role.',
+          ephemeral: true,
+        })
+        return
+      } else {
+        let guildInfo = await getBalancev2(account, interaction.guild.id, roleId)
+        if (!guildInfo) {
+          interaction.reply({ content: 'Error', ephemeral: true })
+          return
         }
-
-        // If they have not verified their EmeraldID...
-
-        let encrypted = encrypt(interaction.member.id);
-    
-        // const botInfo = new MessageEmbed().addField(`Hello there! Please click [this](http://localhost:3000/?id=${args.uuid}) link to gain access to Emerald City.`)
-        const exampleEmbed = new MessageEmbed()
-            .setColor('#5bc595')
-            .setDescription('Click the link below to setup your EmeraldID.')
-            .setTimestamp()
-    
-        const row = new MessageActionRow()
-            .addComponents(
-                new MessageButton()
-                    .setURL('https://pedantic-darwin-e512ad.netlify.app/emeraldID' + '/?id=' + encrypted)
-                    .setLabel('Setup EmeraldID')
-                    .setStyle('LINK')
-            );
-    
-        interaction.reply({ ephemeral: true, embeds: [exampleEmbed], components: [row] });
-    } else if(interaction.customId === 'emeraldiddelete') {
-        let account = await checkEmeraldIdentityDiscord(interaction.member.id);
-        if (!account) {
-            interaction.reply({content: "You do not have an EmeraldID.", ephemeral: true});
-        } else {
-            interaction.reply({content: "Resetting your EmeraldID. Please wait ~20 seconds.", ephemeral: true});
-            let response = await deleteEmeraldID(account, interaction.member.id);
-            if (response) {
-                interaction.editReply({content: "Your EmeraldID has been successfully reset. Please `Verify` again.", ephemeral: true});
-            } else {
-                interaction.editReply({content: "There was an error resetting your EmeraldID.", ephemeral: true});
-            }
+        let { result, number } = guildInfo
+        if (result && result >= number) {
+          console.log('Adding role...')
+          interaction.member.roles.add(roleId).catch((e) => console.log(e))
+          interaction.reply({
+            content: 'You have been given the ' + `<@&${roleId}>` + ' role.',
+            ephemeral: true,
+          })
+          return
         }
+        interaction.reply({ content: 'You do not have enough tokens.', ephemeral: true })
+        return
+      }
     }
-});
+
+    // If they have not verified their EmeraldID...
+
+    let encrypted = encrypt(interaction.member.id)
+
+    // const botInfo = new MessageEmbed().addField(`Hello there! Please click [this](http://localhost:3000/?id=${args.uuid}) link to gain access to Emerald City.`)
+    const exampleEmbed = new MessageEmbed()
+      .setColor('#5bc595')
+      .setDescription('Click the link below to setup your EmeraldID.')
+      .setTimestamp()
+
+    const row = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setURL('https://pedantic-darwin-e512ad.netlify.app/emeraldID' + '/?id=' + encrypted)
+        .setLabel('Setup EmeraldID')
+        .setStyle('LINK'),
+    )
+
+    interaction.reply({ ephemeral: true, embeds: [exampleEmbed], components: [row] })
+  } else if (interaction.customId === 'emeraldiddelete') {
+    let account = await checkEmeraldIdentityDiscord(interaction.member.id)
+    if (!account) {
+      interaction.reply({ content: 'You do not have an EmeraldID.', ephemeral: true })
+    } else {
+      interaction.reply({
+        content: 'Resetting your EmeraldID. Please wait ~20 seconds.',
+        ephemeral: true,
+      })
+      let response = await deleteEmeraldID(account, interaction.member.id)
+      if (response) {
+        interaction.editReply({
+          content: 'Your EmeraldID has been successfully reset. Please `Verify` again.',
+          ephemeral: true,
+        })
+      } else {
+        interaction.editReply({
+          content: 'There was an error resetting your EmeraldID.',
+          ephemeral: true,
+        })
+      }
+    }
+  }
+})
 
 /* SERVER */
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: true }))
 
 app.post('/api/join', async (req, res) => {
-    // Let's ensure that the account proof is legit. 
-    console.log("Account address:", req.body.user.addr)
-    let accountProofObject = req.body.user.services.filter(service => service.type === 'account-proof')[0];
-    if (!accountProofObject) return res.send({"success": 2});
+  // Let's ensure that the account proof is legit.
+  console.log('Account address:', req.body.user.addr)
+  let accountProofObject = req.body.user.services.filter(
+    (service) => service.type === 'account-proof',
+  )[0]
+  if (!accountProofObject) return res.send({ success: 2 })
 
-    const AccountProof = accountProofObject.data;
+  const AccountProof = accountProofObject.data
 
-    let decrypted;
-    try {
-        decrypted = decrypt(req.body.id);
-    } catch(e) {
-        console.log(e);
-        return res.send({"success": 2});
+  let decrypted
+  try {
+    decrypted = decrypt(req.body.id)
+  } catch (e) {
+    console.log(e)
+    return res.send({ success: 2 })
+  }
+
+  let decryptedValues = decrypted.split('///')
+
+  // Gets the balance of the user
+  let guildInfo = await getBalance(
+    AccountProof,
+    decryptedValues[1],
+    decryptedValues[2],
+    req.body.network,
+  )
+  console.log('GuildInfo', guildInfo)
+  if (!guildInfo) return res.send({ success: 2 })
+  let { result, number, role, guildID } = guildInfo
+
+  // 'guild' == the server
+  const guild = client.guilds.cache.get(guildID)
+  // gets the member by first decrypting the uuid and getting back
+  // the member id of the member, then gets the actual member
+
+  try {
+    let member = guild.members.cache.get(decryptedValues[0])
+    console.log('Result: ' + result + ' - ' + 'Number: ' + number)
+    if (result && result >= number) {
+      console.log('Adding role...')
+      member.roles.add(role).catch((e) => console.log(e))
+      return res.send({ success: 1 })
     }
+  } catch (e) {
+    console.log('An error occured decrypting: ' + e)
+  }
 
-    let decryptedValues = decrypted.split('///');
-    
-    // Gets the balance of the user
-    let guildInfo = await getBalance(AccountProof, decryptedValues[1], decryptedValues[2], req.body.network);
-    console.log("GuildInfo", guildInfo)
-    if (!guildInfo) return res.send({"success": 2});
-    let { result, number, role, guildID } = guildInfo;
-
-    // 'guild' == the server
-    const guild = client.guilds.cache.get(guildID)
-    // gets the member by first decrypting the uuid and getting back
-    // the member id of the member, then gets the actual member
-
-    try {
-        let member = guild.members.cache.get(decryptedValues[0])
-        console.log("Result: " + result + " - " + "Number: " + number);
-        if (result && (result >= number)) {
-            console.log("Adding role...");
-            member.roles.add(role).catch((e) => console.log(e));
-            return res.send({"success": 1});
-        }
-    } catch (e) {
-        console.log("An error occured decrypting: " + e);
-    }
-
-    res.send({"success": 2});
-});
+  res.send({ success: 2 })
+})
 
 app.post('/api/sign', async (req, res) => {
-    const { id, user } = req.body;
-    setEnvironment("mainnet");
+  const { id, user, signable } = req.body
+  setEnvironment('mainnet')
 
-    // Validate the user 
-    let accountProofObject = user.services.filter(service => service.type === 'account-proof')[0];
-    if (!accountProofObject) return res.send('ERROR');
+  // Validate the user
+  let accountProofObject = user.services.filter((service) => service.type === 'account-proof')[0]
+  if (!accountProofObject) return res.send('ERROR')
 
-    const AccountProof = accountProofObject.data;
-    const Address = AccountProof.address;
-    const Timestamp = AccountProof.timestamp;
-    console.log(Address)
-    console.log(Timestamp)
-    const Message = fcl.WalletUtils.encodeMessageForProvableAuthnVerifying(
-      Address,                    // Address of the user authenticating
-      Timestamp,                  // Timestamp associated with the authentication
-      "APP-V0.0-user"             // Application domain tag  
-    );
-    const isValid = await fcl.verifyUserSignatures(
-      Message,
-      AccountProof.signatures
-    );
+  const AccountProof = accountProofObject.data
+  const Address = AccountProof.address
+  const Timestamp = AccountProof.timestamp
+  console.log(Address)
+  console.log(Timestamp)
+  const Message = fcl.WalletUtils.encodeMessageForProvableAuthnVerifying(
+    Address, // Address of the user authenticating
+    Timestamp, // Timestamp associated with the authentication
+    'APP-V0.0-user', // Application domain tag
+  )
+  const isValid = await fcl.verifyUserSignatures(Message, AccountProof.signatures)
 
-    if (!isValid) return res.send('ERROR');
+  if (!isValid) return res.send('ERROR')
 
-    // User is now validated //
+  // User is now validated //
 
-    setEnvironment("testnet");
+  setEnvironment('testnet')
 
-    const transactionId = await fcl.send([
-        fcl.transaction`
+  const transactionId = await fcl
+    .send([
+      fcl.transaction`
           import EmeraldIdentity from 0x4e190c2eb6d78faa
       
           transaction(account: Address, discordID: String) {
@@ -246,31 +286,78 @@ app.post('/api/sign', async (req, res) => {
               }
           }
           `,
-          fcl.args([
-              fcl.arg(user.addr, t.Address),
-              fcl.arg(id, t.String)
-          ]),
-          fcl.proposer(authorizationFunctionProposer),
-          fcl.payer(authorizationFunction),
-          fcl.authorizations([authorizationFunction]),
-          fcl.limit(9999)
-    ]).then(fcl.decode);
-    console.log("Transaction Id", transactionId);
+      fcl.args([fcl.arg(user.addr, t.Address), fcl.arg(id, t.String)]),
+      fcl.proposer(authorizationFunctionProposer),
+      fcl.payer(authorizationFunction),
+      fcl.authorizations([authorizationFunction]),
+      fcl.limit(9999),
+    ])
+    .then(fcl.decode)
+  console.log('Transaction Id', transactionId)
 
-    res.json({transactionId});
-
-});
+  res.json({ transactionId })
+})
 
 app.get('/api/getAccount', async (req, res) => {
-    let keyIndex = useKeyId();
-    res.json({
-      address: process.env.ADDRESS,
-      keyIndex,
-    });
-});
+  let keyIndex = 0
+  res.json({
+    address: process.env.ADDRESS,
+    keyIndex,
+  })
+})
 
-app.listen(port, () => console.log(`Listening on port ${port}`));
+app.get('/api/getScript/:scriptName', async (req, res) => {
+  const { scriptName } = req.params
+  const scriptCode = trxScripts[scriptName]()
+  if (scriptName && scriptCode) {
+    res.json({
+      scriptCode,
+    })
+  } else {
+    res.status(500).json({
+      message: 'Cannot get script with script name',
+    })
+  }
+})
+
+app.post('/api/signWithVerify', async (req, res) => {
+  const { user, signable, scriptName } = req.body
+  const scriptCode = trxScripts[scriptName]()
+  setEnvironment('mainnet')
+  // Validate the user
+  let accountProofObject = user.services.filter((service) => service.type === 'account-proof')[0]
+  if (!accountProofObject) return res.send('ERROR')
+
+  const AccountProof = accountProofObject.data
+  const Address = AccountProof.address
+  const Timestamp = AccountProof.timestamp
+  console.log(Address)
+  console.log(Timestamp)
+  const Message = fcl.WalletUtils.encodeMessageForProvableAuthnVerifying(
+    Address, // Address of the user authenticating
+    Timestamp, // Timestamp associated with the authentication
+    'APP-V0.0-user', // Application domain tag
+  )
+  // const isValid = await fcl.verifyUserSignatures(Message, AccountProof.signatures)
+
+  // if (!isValid) return res.send('ERROR')
+
+  // User is now validated //
+
+  setEnvironment('testnet')
+
+  const { voucher = {}, message } = signable
+  const { cadence = '' } = voucher
+  if (scriptCode == cadence) {
+    const signature = sign(message)
+    res.json({ signature })
+  } else {
+    res.status(500).json({ message: 'Script code invalid' })
+  }
+})
+
+app.listen(port, () => console.log(`Listening on port ${port}`))
 
 // This is the bot's token
 // Must be at the bottom of the file
-client.login(process.env.TOKEN);
+client.login(process.env.TOKEN)

--- a/main.js
+++ b/main.js
@@ -192,7 +192,7 @@ client.on('interactionCreate', async (interaction) => {
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
 
-const verifyUserDataWithBlocto = (user) => {
+const verifyUserDataWithBlocto = async (user) => {
   setEnvironment('mainnet')
   // Validate the user
   let accountProofObject = user.services.filter((service) => service.type === 'account-proof')[0]
@@ -268,7 +268,7 @@ app.post('/api/sign', async (req, res) => {
   setEnvironment('mainnet')
 
   // validate user data with blocto
-  const isValid = verifyUserDataWithBlocto(user)
+  const isValid = await verifyUserDataWithBlocto(user)
   if (!isValid) return res.status(500).json({ mesage: 'User data validate failed' })
 
   // User is now validated //
@@ -334,7 +334,7 @@ app.post('/api/signWithVerify', async (req, res) => {
   const scriptCode = trxScripts[scriptName]()
 
   // validate user data with blocto
-  const isValid = verifyUserDataWithBlocto(user)
+  const isValid = await verifyUserDataWithBlocto(user)
   if (!isValid) return res.status(500).json({ mesage: 'User data validate failed' })
 
   // User is now validated //

--- a/main.js
+++ b/main.js
@@ -196,7 +196,7 @@ const verifyUserDataWithBlocto = (user) => {
   setEnvironment('mainnet')
   // Validate the user
   let accountProofObject = user.services.filter((service) => service.type === 'account-proof')[0]
-  if (!accountProofObject) return res.send('ERROR')
+  if (!accountProofObject) return false
 
   const AccountProof = accountProofObject.data
   const Address = AccountProof.address
@@ -269,7 +269,7 @@ app.post('/api/sign', async (req, res) => {
 
   // validate user data with blocto
   const isValid = verifyUserDataWithBlocto(user)
-  if (!isValid) return res.send('ERROR')
+  if (!isValid) return res.status(500).json({ mesage: 'User data validate failed' })
 
   // User is now validated //
 
@@ -335,7 +335,7 @@ app.post('/api/signWithVerify', async (req, res) => {
 
   // validate user data with blocto
   const isValid = verifyUserDataWithBlocto(user)
-  if (!isValid) return res.send('ERROR')
+  if (!isValid) return res.status(500).json({ mesage: 'User data validate failed' })
 
   // User is now validated //
 


### PR DESCRIPTION
`/api/getScript/:scriptName` for client query the script with key
for now we support `initializeEmeraldID` and `deleteEmeraldID` with multi-sign verify

`/api/signWithVerify` for multi-sign from the client with Cadence script code

```
// fetch code from signable.voucher and match with the script to make sure the request auth is safe
 const { voucher = {}, message } = signable
  const { cadence = '' } = voucher
  if (scriptCode == cadence) {
    // when the code match , will sign the transaction
    const signature = sign(message)
    res.json({ signature })
  } else {
    res.status(500).json({ message: 'Script code not supported' })
  }
```